### PR TITLE
lock should expire automaticaly if lock owner gone

### DIFF
--- a/src/main/java/org/redisson/connection/ConnectionManager.java
+++ b/src/main/java/org/redisson/connection/ConnectionManager.java
@@ -16,6 +16,8 @@
 package org.redisson.connection;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
 import io.netty.util.concurrent.Future;
 
 import org.redisson.async.AsyncOperation;
@@ -23,6 +25,8 @@ import org.redisson.async.SyncOperation;
 
 import com.lambdaworks.redis.RedisConnection;
 import com.lambdaworks.redis.pubsub.RedisPubSubAdapter;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -76,4 +80,5 @@ public interface ConnectionManager {
 
     EventLoopGroup getGroup();
 
+    Timeout newTimeout(TimerTask task, long delay, TimeUnit unit);
 }

--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -670,4 +670,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         return group;
     }
 
+    @Override
+    public Timeout newTimeout(TimerTask task, long delay, TimeUnit unit) {
+        return timer.newTimeout(task, delay, unit);
+    }
+
 }


### PR DESCRIPTION
Currently if redisson client was shutdown abnormally locks created by this client will  remain forever.
This solution will create all locks as keys with expiration time set in redis. I'm not sure if this is best solution and what to do with lock() - lock(time, unit) - lock() sequences but it works for me.
Any suggestions or changes are welcome.