### PR TITLE
Expose org.redisson.codec package for OSGi bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
                <instructions>
                    <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                    <Export-Package>
+                    org.redisson.codec;version="${project.version}",
                     org.redisson.core;version="${project.version}",
                     org.redisson;version="${project.version}",
                    </Export-Package>


### PR DESCRIPTION
If you try to use a non-default codec in an OSGi situation, the bundle fails to start. In order to resolve this, the codec package needs to be exposed in the OSGi manifest.