### PR TITLE
Remove Export-Package and allow maven-bundle-plugin to use defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
            <configuration>
                <instructions>
                    <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                   <Export-Package>
-                    org.redisson.codec;version="${project.version}",
-                    org.redisson.core;version="${project.version}",
-                    org.redisson;version="${project.version}",
-                   </Export-Package>
                </instructions>
            </configuration>
         </plugin>


### PR DESCRIPTION
After further investigation, there seems to be a few packages that are not exported which are required. For example, the class RedisException. Rather than adding each package to the export-package list, use the maven-bundle-plugin to generate the exports using the in-built filters.