### PR TITLE
Incorrect map key encoding makes RMap.getAll return no fields

### DIFF
--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
@@ -415,7 +415,7 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
     }
 
     public Future<List<V>> hmget(K key, K... fields) {
-        CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKeys(fields);
+        CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addMapKeys(fields);
         return dispatch(HMGET, new ValueListOutput<K, V>(codec), args);
     }
 

--- a/src/test/java/org/redisson/RedissonMapTest.java
+++ b/src/test/java/org/redisson/RedissonMapTest.java
@@ -147,6 +147,22 @@ public class RedissonMapTest extends BaseTest {
     }
 
     @Test
+    public void testGetAllWithStringKeys() {
+        RMap<String, Integer> map = redisson.getMap("getAllStrings");
+        map.put("A", 100);
+        map.put("B", 200);
+        map.put("C", 300);
+        map.put("D", 400);
+
+        Map<String, Integer> filtered = map.getAll(new HashSet<String>(Arrays.asList("B", "C", "E")));
+
+        Map<String, Integer> expectedMap = new HashMap<String, Integer>();
+        expectedMap.put("B", 200);
+        expectedMap.put("C", 300);
+        Assert.assertEquals(expectedMap, filtered);
+    }
+
+    @Test
     public void testFilterKeys() {
         RMap<Integer, Integer> map = redisson.getMap("filterKeys");
         map.put(1, 100);


### PR DESCRIPTION
RedisAsyncConnection.hmget encodes the fields parameter using addKeys rather than addMapKeys. When strings are used for keys, using the default JsonJacksonCodec, these keys are normally quoted when stored in redis, but addKeys does not quote these strings making the ReddisonMap.getAll, which uses hmget, return an empty map in all scenarios.