### PR TITLE
Bugfix for RedissonBlockingQueue#drainTo method with maxElements

### DIFF
--- a/src/main/java/org/redisson/RedissonBlockingQueue.java
+++ b/src/main/java/org/redisson/RedissonBlockingQueue.java
@@ -130,8 +130,8 @@ public class RedissonBlockingQueue<V> extends RedissonQueue<V> implements RBlock
                         return Collections.emptyList();
                     }
                     conn.multi();
-                    conn.lrange(getName(), 0, len);
-                    conn.ltrim(getName(), 0, len);
+                    conn.lrange(getName(), 0, len - 1);
+                    conn.ltrim(getName(), len, -1);
                     List<Object> res = conn.exec();
                     if (res.size() == 2) {
                         List<V> items = (List<V>) res.get(0);

--- a/src/test/java/org/redisson/RedissonBlockingQueueTest.java
+++ b/src/test/java/org/redisson/RedissonBlockingQueueTest.java
@@ -102,6 +102,24 @@ public class RedissonBlockingQueueTest extends BaseTest {
     }
 
     @Test
+    public void testDrainTo() {
+        RBlockingQueue<Integer> queue = redisson.getBlockingQueue("queue");
+        for (int i = 0 ; i < 100; i++) {
+            queue.offer(i);
+        }
+        Assert.assertEquals(100, queue.size());
+        Set<Integer> batch = new HashSet<Integer>();
+        int count = queue.drainTo(batch, 10);
+        Assert.assertEquals(10, count);
+        Assert.assertEquals(10, batch.size());
+        Assert.assertEquals(90, queue.size());
+        queue.drainTo(batch, 10);
+        queue.drainTo(batch, 20);
+        queue.drainTo(batch, 60);
+        Assert.assertEquals(0, queue.size());
+    }
+
+    @Test
     public void testBlockingQueue() {
 
         RBlockingQueue<Integer> queue = redisson.getBlockingQueue("test_:blocking:queue:");


### PR DESCRIPTION
Found incorrect behaviour of queue.drainTo(collection, maxElements). It was filling the collection of elements with a trimming  all another elements in redis list. So, all subsequent calls of method returned collection of duplicated elements.