### PR TITLE
Propagate response processing exceptions to ConnectionManager

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/Command.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/Command.java
@@ -67,7 +67,7 @@ public class Command<K, V, T> {
             }
             if (res instanceof RedisException) {
                 promise.setFailure((Exception)res);
-            } if (output.hasError()) {
+            } else if (output.hasError()) {
                 if (output.getError().startsWith("MOVED")) {
                     String[] parts = output.getError().split(" ");
                     int slot = Integer.valueOf(parts[1]);
@@ -75,6 +75,8 @@ public class Command<K, V, T> {
                 } else {
                     promise.setFailure(new RedisException(output.getError()));
                 }
+            } else if (output.hasException()) {
+                promise.setFailure(output.getException());
             } else {
                 promise.setSuccess((T)res);
             }

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandOutput.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandOutput.java
@@ -17,6 +17,7 @@ public abstract class CommandOutput<K, V, T> {
     protected RedisCodec<K, V> codec;
     protected T output;
     protected String error;
+    protected Throwable exception;
 
     /**
      * Initialize a new instance that encodes and decodes keys and
@@ -95,6 +96,33 @@ public abstract class CommandOutput<K, V, T> {
      */
     public String getError() {
         return error;
+    }
+
+    /**
+     * Set exception that was caught while processing result in command output.
+     *
+     * @param exception Exception caught while processing command result.
+     */
+    public void setException(Throwable exception) {
+        this.exception = exception;
+    }
+
+    /**
+     * Check if the processing command result resulted in an exception.
+     *
+     * @return true if processing of command result resulted in an exception.
+     */
+    public boolean hasException() {
+        return this.exception != null;
+    }
+
+    /**
+     * Get the exception that occurred while processing command result.
+     *
+     * @return The exception.
+     */
+    public Throwable getException () {
+        return exception;
     }
 
     /**

--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -410,7 +410,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         if (future.isSuccess()) {
             return future.getNow();
         }
-        throw ((RedisException)future.cause());
+        throw future.cause() instanceof RedisException ?
+                (RedisException) future.cause() :
+                new RedisException("Unexpected exception while processing command", future.cause());
     }
 
     public <V, T> T read(String key, AsyncOperation<V, T> asyncOperation) {


### PR DESCRIPTION
This pull request is related to #169. First commit is just adding test case that is proving reported bug in the issue.

Second commit is proposed simple fix. Feel free to give me some feedback if anything needs to be changed or improved.

Have in mind, that this solution only protects CommandHandler from exceptions in CommandOutput.set methods. If exception is thrown somewhere else in RedisStateMachine, bug will still exists even after this fix.

