### PR TITLE
Use LUA scripts for transactional redis operations

### DIFF
--- a/src/main/java/com/lambdaworks/redis/ScriptOutputType.java
+++ b/src/main/java/com/lambdaworks/redis/ScriptOutputType.java
@@ -10,6 +10,7 @@ package com.lambdaworks.redis;
  *  <li>{@link #INTEGER} 64-bit integer</li>
  *  <li>{@link #STATUS}  status string</li>
  *  <li>{@link #VALUE}   value</li>
+ *  <li>{@link #MAPVALUE}  typed value</li>
  *  <li>{@link #MULTI}   of these types</li>.
  * </ul>
  *

--- a/src/main/java/com/lambdaworks/redis/output/IntegerOutput.java
+++ b/src/main/java/com/lambdaworks/redis/output/IntegerOutput.java
@@ -5,7 +5,9 @@ package com.lambdaworks.redis.output;
 import com.lambdaworks.redis.codec.RedisCodec;
 import com.lambdaworks.redis.protocol.CommandOutput;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 /**
  * 64-bit integer output, may be null.
@@ -24,6 +26,6 @@ public class IntegerOutput<K, V> extends CommandOutput<K, V, Long> {
 
     @Override
     public void set(ByteBuffer bytes) {
-        output = null;
+        output = bytes == null ? null : new Long(decodeAscii(bytes));
     }
 }

--- a/src/main/java/com/lambdaworks/redis/output/MapScanOutput.java
+++ b/src/main/java/com/lambdaworks/redis/output/MapScanOutput.java
@@ -16,7 +16,7 @@ public class MapScanOutput<K, V> extends CommandOutput<K, V, MapScanResult<K, V>
     @Override
     public void set(ByteBuffer bytes) {
         if (output.getPos() == null) {
-            output.setPos(((Number) codec.decodeValue(bytes)).longValue());
+            output.setPos(toLong(bytes));
         } else {
             if (counter % 2 == 0) {
                 output.addValue(codec.decodeMapValue(bytes));
@@ -26,5 +26,10 @@ public class MapScanOutput<K, V> extends CommandOutput<K, V, MapScanResult<K, V>
         }
         counter++;
     }
+
+    private Long toLong(ByteBuffer bytes) {
+        return bytes == null ? null : new Long(new String(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.limit()));
+    }
+
 
 }

--- a/src/main/java/com/lambdaworks/redis/output/ValueSetScanOutput.java
+++ b/src/main/java/com/lambdaworks/redis/output/ValueSetScanOutput.java
@@ -14,10 +14,14 @@ public class ValueSetScanOutput<K, V> extends CommandOutput<K, V, ListScanResult
     @Override
     public void set(ByteBuffer bytes) {
         if (output.getPos() == null) {
-            output.setPos(Long.valueOf(codec.decodeMapValue(bytes).toString()));
+            output.setPos(toLong(bytes));
         } else {
             output.addValue(codec.decodeMapValue(bytes));
         }
+    }
+
+    private Long toLong(ByteBuffer bytes) {
+        return bytes == null ? null : new Long(new String(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.limit()));
     }
 
 }

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
@@ -3,8 +3,10 @@
 package com.lambdaworks.redis.protocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufProcessor;
 import io.netty.channel.*;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.StringUtil;
 
 import java.util.concurrent.BlockingQueue;
 
@@ -63,8 +65,26 @@ public class CommandHandler<K, V> extends ChannelDuplexHandler {
         ByteBuf buf = ctx.alloc().heapBuffer();
         cmd.encode(buf);
 //        System.out.println("out: " + buf.toString(CharsetUtil.UTF_8));
+//        System.out.println("out: " + toHexString(buf));
 
         ctx.write(buf, promise);
+    }
+
+    private String toHexString(ByteBuf buf) {
+        final StringBuilder builder = new StringBuilder(buf.readableBytes() * 2);
+        buf.forEachByte(new ByteBufProcessor() {
+            @Override
+            public boolean process(byte value) throws Exception {
+                char b = (char) value;
+                if ((b < ' ' && b != '\n' && b != '\r') || b > '~') {
+                    builder.append("\\x").append(StringUtil.byteToHexStringPadded(value));
+                } else {
+                    builder.append(b);
+                }
+                return true;
+            }
+        });
+        return builder.toString();
     }
 
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer) throws InterruptedException {

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
@@ -48,7 +48,7 @@ public class CommandHandler<K, V> extends ChannelDuplexHandler {
         try {
             if (!input.isReadable()) return;
 
-//            System.out.println("in: " + input.toString(CharsetUtil.UTF_8));
+//            System.out.println("in: " + toHexString(input));
 
             buffer.discardReadBytes();
             buffer.writeBytes(input);
@@ -64,7 +64,6 @@ public class CommandHandler<K, V> extends ChannelDuplexHandler {
         Command<?, ?, ?> cmd = (Command<?, ?, ?>) msg;
         ByteBuf buf = ctx.alloc().heapBuffer();
         cmd.encode(buf);
-//        System.out.println("out: " + buf.toString(CharsetUtil.UTF_8));
 //        System.out.println("out: " + toHexString(buf));
 
         ctx.write(buf, promise);

--- a/src/main/java/org/redisson/RedissonMap.java
+++ b/src/main/java/org/redisson/RedissonMap.java
@@ -15,16 +15,14 @@
  */
 package org.redisson;
 
-import java.math.BigDecimal;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
 
+import java.math.BigDecimal;
+import java.util.*;
+
+import org.redisson.async.AsyncOperation;
+import org.redisson.async.OperationListener;
 import org.redisson.async.ResultOperation;
 import org.redisson.connection.ConnectionManager;
 import org.redisson.core.Predicate;
@@ -32,6 +30,7 @@ import org.redisson.core.RMap;
 import org.redisson.core.RScript;
 
 import com.lambdaworks.redis.RedisAsyncConnection;
+import com.lambdaworks.redis.RedisConnection;
 import com.lambdaworks.redis.output.MapScanResult;
 
 import io.netty.util.concurrent.Future;
@@ -129,6 +128,9 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
 
     @Override
     public void putAll(final Map<? extends K, ? extends V> map) {
+        if (map.size() == 0) {
+            return;
+        }
         connectionManager.write(getName(), new ResultOperation<String, Object>() {
             @Override
             public Future<String> execute(RedisAsyncConnection<Object, Object> async) {

--- a/src/main/java/org/redisson/RedissonScript.java
+++ b/src/main/java/org/redisson/RedissonScript.java
@@ -71,6 +71,21 @@ public class RedissonScript implements RScript {
     }
 
     @Override
+    public <R> R evalR(String luaScript, ReturnType returnType, List<Object> keys, List<?> values, List<?> rawValues) {
+        return (R) connectionManager.get(evalAsyncR(luaScript, returnType, keys, values, rawValues));
+    }
+
+    @Override
+    public <R> Future<R> evalAsyncR(final String luaScript, final ReturnType returnType, final List<Object> keys, final List<?> values, final List<?> rawValues) {
+        return connectionManager.writeAsync(new ResultOperation<R, Object>() {
+            @Override
+            protected Future<R> execute(RedisAsyncConnection<Object, Object> async) {
+                return async.evalR(luaScript, ScriptOutputType.valueOf(returnType.toString()), keys, values, rawValues);
+            }
+        });
+    }
+
+    @Override
     public <R> R evalSha(String shaDigest, ReturnType returnType) {
         return evalSha(shaDigest, returnType, Collections.emptyList());
     }

--- a/src/main/java/org/redisson/RedissonSet.java
+++ b/src/main/java/org/redisson/RedissonSet.java
@@ -18,10 +18,7 @@ package org.redisson;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 
 import org.redisson.async.AsyncOperation;
 import org.redisson.async.OperationListener;
@@ -121,7 +118,7 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V> {
                 }
 
                 // lazy init iterator
-                hasNext();
+//                hasNext();
                 iter.remove();
                 RedissonSet.this.remove(value);
                 removeExecuted = true;
@@ -207,7 +204,7 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V> {
         if (c.isEmpty()) {
             return false;
         }
-        
+
         Long res = connectionManager.write(getName(), new ResultOperation<Long, Object>() {
             @Override
             public Future<Long> execute(RedisAsyncConnection<Object, Object> async) {
@@ -219,14 +216,13 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V> {
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        boolean changed = false;
-        for (Object object : this) {
+        List<V> toRemove = new ArrayList<V>();
+        for (V object : this) {
             if (!c.contains(object)) {
-                remove(object);
-                changed = true;
+                toRemove.add(object);
             }
         }
-        return changed;
+        return removeAll(toRemove);
     }
 
     @Override

--- a/src/main/java/org/redisson/codec/SerializationCodec.java
+++ b/src/main/java/org/redisson/codec/SerializationCodec.java
@@ -15,11 +15,9 @@
  */
 package org.redisson.codec;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 /**
  *
@@ -30,7 +28,7 @@ public class SerializationCodec implements RedissonCodec {
 
     @Override
     public Object decodeKey(ByteBuffer bytes) {
-        return decode(bytes);
+        return new String(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.limit(), Charset.forName("ASCII"));
     }
 
     @Override
@@ -50,7 +48,7 @@ public class SerializationCodec implements RedissonCodec {
 
     @Override
     public byte[] encodeKey(Object key) {
-        return encodeValue(key);
+        return key.toString().getBytes(Charset.forName("ASCII"));
     }
 
     @Override
@@ -73,7 +71,7 @@ public class SerializationCodec implements RedissonCodec {
 
     @Override
     public byte[] encodeMapKey(Object key) {
-        return encodeKey(key);
+        return encodeValue(key);
     }
 
     @Override
@@ -83,7 +81,18 @@ public class SerializationCodec implements RedissonCodec {
 
     @Override
     public Object decodeMapKey(ByteBuffer bytes) {
-        return decodeKey(bytes);
+        return decodeValue(bytes);
+    }
+
+    protected String decodeAscii(ByteBuffer bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        char[] chars = new char[bytes.remaining()];
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = (char) bytes.get();
+        }
+        return new String(chars);
     }
 
 }

--- a/src/main/java/org/redisson/connection/ConnectionManager.java
+++ b/src/main/java/org/redisson/connection/ConnectionManager.java
@@ -16,6 +16,8 @@
 package org.redisson.connection;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
 import io.netty.util.concurrent.Future;
 
 import org.redisson.async.AsyncOperation;
@@ -25,6 +27,8 @@ import org.redisson.async.SyncOperation;
 import com.lambdaworks.redis.RedisClient;
 import com.lambdaworks.redis.RedisConnection;
 import com.lambdaworks.redis.pubsub.RedisPubSubAdapter;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -86,4 +90,5 @@ public interface ConnectionManager {
 
     EventLoopGroup getGroup();
 
+    Timeout newTimeout(TimerTask task, long delay, TimeUnit unit);
 }

--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -735,4 +735,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         return group;
     }
 
+    @Override
+    public Timeout newTimeout(TimerTask task, long delay, TimeUnit unit) {
+        return timer.newTimeout(task, delay, unit);
+    }
+
 }

--- a/src/main/java/org/redisson/core/RScript.java
+++ b/src/main/java/org/redisson/core/RScript.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public interface RScript {
     
-    enum ReturnType {BOOLEAN, INTEGER, MULTI, STATUS, VALUE};
+    enum ReturnType {BOOLEAN, INTEGER, MULTI, STATUS, VALUE, MAPVALUE, MAPVALUELIST};
 
     List<Boolean> scriptExists(String ... shaDigests);
     
@@ -38,7 +38,11 @@ public interface RScript {
     String scriptLoad(String luaScript);
     
     Future<String> scriptLoadAsync(String luaScript);
-    
+
+    <R> R evalR(String luaScript, ReturnType returnType, List<Object> keys, List<?> values, List<?> rawValues);
+
+    <R> Future<R> evalAsyncR(String luaScript, ReturnType returnType, List<Object> keys, List<?> values, List<?> rawValues);
+
     <R> R evalSha(String shaDigest, ReturnType returnType);
     
     <R> R evalSha(String shaDigest, ReturnType returnType, List<Object> keys, Object... values);

--- a/src/test/java/org/redisson/BaseConcurrentTest.java
+++ b/src/test/java/org/redisson/BaseConcurrentTest.java
@@ -11,11 +11,11 @@ import java.util.concurrent.TimeUnit;
 public abstract class BaseConcurrentTest {
 
     protected void testMultiInstanceConcurrency(int iterations, final RedissonRunnable runnable) throws InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()*2);
+        ExecutorService executor = Executors.newCachedThreadPool();
 
         final Map<Integer, Redisson> instances = new HashMap<Integer, Redisson>();
         for (int i = 0; i < iterations; i++) {
-            instances.put(i, Redisson.create());
+            instances.put(i, BaseTest.createInstance());
         }
 
         long watch = System.currentTimeMillis();
@@ -35,7 +35,7 @@ public abstract class BaseConcurrentTest {
 
         System.out.println("multi: " + (System.currentTimeMillis() - watch));
 
-        executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        executor = Executors.newCachedThreadPool();
 
         for (final Redisson redisson : instances.values()) {
             executor.execute(new Runnable() {
@@ -53,7 +53,7 @@ public abstract class BaseConcurrentTest {
     protected void testSingleInstanceConcurrency(int iterations, final RedissonRunnable runnable) throws InterruptedException {
         ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-        final Redisson redisson = Redisson.create();
+        final Redisson redisson = BaseTest.createInstance();
         long watch = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
             executor.execute(new Runnable() {

--- a/src/test/java/org/redisson/BaseTest.java
+++ b/src/test/java/org/redisson/BaseTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.redisson.codec.SerializationCodec;
 
 public abstract class BaseTest {
 
@@ -13,7 +14,18 @@ public abstract class BaseTest {
 
     @Before
     public void before() {
-        redisson = Redisson.create();
+        this.redisson = createInstance();
+    }
+
+    public static Redisson createInstance() {
+        String redisAddress = System.getProperty("redisAddress");
+        if (redisAddress == null) {
+            redisAddress = "127.0.0.1:6379";
+        }
+        Config config = new Config();
+        config.useSingleServer().setAddress(redisAddress);
+//        config.setCodec(new SerializationCodec());
+        return Redisson.create(config);
     }
 
     @After

--- a/src/test/java/org/redisson/ConcurrentRedissonSortedSetTest.java
+++ b/src/test/java/org/redisson/ConcurrentRedissonSortedSetTest.java
@@ -17,7 +17,7 @@ public class ConcurrentRedissonSortedSetTest extends BaseConcurrentTest {
     public void testAdd_SingleInstance() throws InterruptedException {
         final String name = "testAdd_SingleInstance";
 
-        Redisson r = Redisson.create();
+        Redisson r = BaseTest.createInstance();
         RSortedSet<Integer> map = r.getSortedSet(name);
         map.clear();
 
@@ -54,7 +54,7 @@ public class ConcurrentRedissonSortedSetTest extends BaseConcurrentTest {
     public void testAddNegative_SingleInstance() throws InterruptedException {
         final String name = "testAddNegative_SingleInstance";
 
-        Redisson r = Redisson.create();
+        Redisson r = BaseTest.createInstance();
         RSortedSet<Integer> map = r.getSortedSet(name);
         map.clear();
 

--- a/src/test/java/org/redisson/RedissonBlockingQueueTest.java
+++ b/src/test/java/org/redisson/RedissonBlockingQueueTest.java
@@ -152,4 +152,36 @@ public class RedissonBlockingQueueTest extends BaseTest {
         assertThat(counter.get(), equalTo(total));
         queue.delete();
     }
+
+    @Test
+    public void testDrainToCollection() throws Exception {
+        RBlockingQueue<Object> queue1 = redisson.getBlockingQueue("queue1");
+        queue1.put(1);
+        queue1.put(2L);
+        queue1.put("e");
+
+        ArrayList<Object> dst = new ArrayList<Object>();
+        queue1.drainTo(dst);
+        MatcherAssert.assertThat(dst, Matchers.<Object>contains(1, 2L, "e"));
+        Assert.assertEquals(0, queue1.size());
+    }
+
+    @Test
+    public void testDrainToCollectionLimited() throws Exception {
+        RBlockingQueue<Object> queue1 = redisson.getBlockingQueue("queue1");
+        queue1.put(1);
+        queue1.put(2L);
+        queue1.put("e");
+
+        ArrayList<Object> dst = new ArrayList<Object>();
+        queue1.drainTo(dst, 2);
+        MatcherAssert.assertThat(dst, Matchers.<Object>contains(1, 2L));
+        Assert.assertEquals(1, queue1.size());
+
+        dst.clear();
+        queue1.drainTo(dst, 2);
+        MatcherAssert.assertThat(dst, Matchers.<Object>contains("e"));
+
+
+    }
 }

--- a/src/test/java/org/redisson/RedissonConcurrentMapTest.java
+++ b/src/test/java/org/redisson/RedissonConcurrentMapTest.java
@@ -13,7 +13,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void testSingleReplaceOldValue_SingleInstance() throws InterruptedException {
         final String name = "testSingleReplaceOldValue_SingleInstance";
 
-        ConcurrentMap<String, String> map = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> map = BaseTest.createInstance().getMap(name);
         map.put("1", "122");
 
         testSingleInstanceConcurrency(100, new RedissonRunnable() {
@@ -25,7 +25,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
             }
         });
 
-        ConcurrentMap<String, String> testMap = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> testMap = BaseTest.createInstance().getMap(name);
         Assert.assertEquals("32", testMap.get("1"));
 
         assertMapSize(1, name);
@@ -35,7 +35,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void testSingleRemoveValue_SingleInstance() throws InterruptedException {
         final String name = "testSingleRemoveValue_SingleInstance";
 
-        ConcurrentMap<String, String> map = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> map = BaseTest.createInstance().getMap(name);
         map.putIfAbsent("1", "0");
         testSingleInstanceConcurrency(100, new RedissonRunnable() {
             @Override
@@ -52,7 +52,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void testSingleReplace_SingleInstance() throws InterruptedException {
         final String name = "testSingleReplace_SingleInstance";
 
-        ConcurrentMap<String, String> map = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> map = BaseTest.createInstance().getMap(name);
         map.put("1", "0");
 
         testSingleInstanceConcurrency(100, new RedissonRunnable() {
@@ -63,7 +63,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
             }
         });
 
-        ConcurrentMap<String, String> testMap = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> testMap = BaseTest.createInstance().getMap(name);
         Assert.assertEquals("3", testMap.get("1"));
 
         assertMapSize(1, name);
@@ -73,7 +73,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void test_Multi_Replace_MultiInstance() throws InterruptedException {
         final String name = "test_Multi_Replace_MultiInstance";
 
-        Redisson redisson = Redisson.create();
+        Redisson redisson = BaseTest.createInstance();
         ConcurrentMap<Integer, Integer> map = redisson.getMap(name);
         for (int i = 0; i < 5; i++) {
             map.put(i, 1);
@@ -88,7 +88,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
             }
         });
 
-        ConcurrentMap<Integer, Integer> testMap = Redisson.create().getMap(name);
+        ConcurrentMap<Integer, Integer> testMap = BaseTest.createInstance().getMap(name);
         for (Integer value : testMap.values()) {
             Assert.assertEquals(2, (int)value);
         }
@@ -102,7 +102,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void test_Multi_RemoveValue_MultiInstance() throws InterruptedException {
         final String name = "test_Multi_RemoveValue_MultiInstance";
 
-        ConcurrentMap<Integer, Integer> map = Redisson.create().getMap(name);
+        ConcurrentMap<Integer, Integer> map = BaseTest.createInstance().getMap(name);
         for (int i = 0; i < 10; i++) {
             map.put(i, 1);
         }
@@ -123,7 +123,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     public void testSinglePutIfAbsent_SingleInstance() throws InterruptedException {
         final String name = "testSinglePutIfAbsent_SingleInstance";
 
-        ConcurrentMap<String, String> map = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> map = BaseTest.createInstance().getMap(name);
         map.putIfAbsent("1", "0");
         testSingleInstanceConcurrency(100, new RedissonRunnable() {
             @Override
@@ -133,7 +133,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
             }
         });
 
-        ConcurrentMap<String, String> testMap = Redisson.create().getMap(name);
+        ConcurrentMap<String, String> testMap = BaseTest.createInstance().getMap(name);
         Assert.assertEquals("0", testMap.get("1"));
 
         assertMapSize(1, name);
@@ -168,7 +168,7 @@ public class RedissonConcurrentMapTest extends BaseConcurrentTest {
     }
 
     private void assertMapSize(int size, String name) {
-        Map<String, String> map = Redisson.create().getMap(name);
+        Map<String, String> map = BaseTest.createInstance().getMap(name);
         Assert.assertEquals(size, map.size());
         clear(map);
     }

--- a/src/test/java/org/redisson/RedissonCountDownLatchConcurrentTest.java
+++ b/src/test/java/org/redisson/RedissonCountDownLatchConcurrentTest.java
@@ -15,7 +15,7 @@ public class RedissonCountDownLatchConcurrentTest {
     public void testSingleCountDownAwait_SingleInstance() throws InterruptedException {
         final int iterations = Runtime.getRuntime().availableProcessors()*3;
 
-        Redisson redisson = Redisson.create();
+        Redisson redisson = BaseTest.createInstance();
         final RCountDownLatch latch = redisson.getCountDownLatch("latch");
         latch.trySetCount(iterations);
 

--- a/src/test/java/org/redisson/RedissonCountDownLatchTest.java
+++ b/src/test/java/org/redisson/RedissonCountDownLatchTest.java
@@ -8,12 +8,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.redisson.core.RCountDownLatch;
 
-public class RedissonCountDownLatchTest {
+public class RedissonCountDownLatchTest extends BaseTest {
 
     @Test
     public void testAwaitTimeout() throws InterruptedException {
-        Redisson redisson = Redisson.create();
-
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
         final RCountDownLatch latch = redisson.getCountDownLatch("latch1");
@@ -48,13 +46,10 @@ public class RedissonCountDownLatchTest {
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
 
-        redisson.shutdown();
     }
 
     @Test
     public void testAwaitTimeoutFail() throws InterruptedException {
-        Redisson redisson = Redisson.create();
-
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
         final RCountDownLatch latch = redisson.getCountDownLatch("latch1");
@@ -88,15 +83,14 @@ public class RedissonCountDownLatchTest {
 
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-
-        redisson.shutdown();
     }
 
     @Test
     public void testCountDown() throws InterruptedException {
-        Redisson redisson = Redisson.create();
         RCountDownLatch latch = redisson.getCountDownLatch("latch");
-        latch.trySetCount(1);
+        latch.trySetCount(2);
+        Assert.assertEquals(2, latch.getCount());
+        latch.countDown();
         Assert.assertEquals(1, latch.getCount());
         latch.countDown();
         Assert.assertEquals(0, latch.getCount());
@@ -131,8 +125,25 @@ public class RedissonCountDownLatchTest {
         latch4.countDown();
         Assert.assertEquals(0, latch.getCount());
         latch4.await();
-
-        redisson.shutdown();
     }
 
+    @Test
+    public void testDelete() throws Exception {
+        RCountDownLatch latch = redisson.getCountDownLatch("latch");
+        latch.trySetCount(1);
+        Assert.assertTrue(latch.delete());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDeleteFailed() throws Exception {
+        RCountDownLatch latch = redisson.getCountDownLatch("latch");
+        Assert.assertTrue(latch.delete());
+    }
+
+    @Test
+    public void testTrySetCount() throws Exception {
+        RCountDownLatch latch = redisson.getCountDownLatch("latch");
+        Assert.assertTrue(latch.trySetCount(1));
+        Assert.assertFalse(latch.trySetCount(2));
+    }
 }

--- a/src/test/java/org/redisson/RedissonMapTest.java
+++ b/src/test/java/org/redisson/RedissonMapTest.java
@@ -389,6 +389,22 @@ public class RedissonMapTest extends BaseTest {
     }
 
     @Test
+    public void testPutIfAbsent() throws Exception {
+        ConcurrentMap<SimpleKey, SimpleValue> map = redisson.getMap("simple");
+        SimpleKey key = new SimpleKey("1");
+        SimpleValue value = new SimpleValue("2");
+        map.put(key, value);
+        Assert.assertEquals(value, map.putIfAbsent(key, new SimpleValue("3")));
+        Assert.assertEquals(value, map.get(key));
+
+        SimpleKey key1 = new SimpleKey("2");
+        SimpleValue value1 = new SimpleValue("4");
+        Assert.assertNull(map.putIfAbsent(key1, value1));
+        Assert.assertEquals(value1, map.get(key1));
+
+    }
+
+    @Test
     public void testSize() {
         Map<SimpleKey, SimpleValue> map = redisson.getMap("simple");
 

--- a/src/test/java/org/redisson/RedissonSetTest.java
+++ b/src/test/java/org/redisson/RedissonSetTest.java
@@ -2,13 +2,8 @@ package org.redisson;
 
 import io.netty.util.concurrent.Future;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
+import java.io.Serializable;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import org.hamcrest.MatcherAssert;
@@ -20,7 +15,7 @@ import org.redisson.core.RSortedSet;
 
 public class RedissonSetTest extends BaseTest {
 
-    public static class SimpleBean {
+    public static class SimpleBean implements Serializable {
 
         private Long lng;
 
@@ -158,13 +153,36 @@ public class RedissonSetTest extends BaseTest {
     @Test
     public void testRetainAll() {
         Set<Integer> set = redisson.getSet("set");
-        for (int i = 0; i < 200; i++) {
+        for (int i = 0; i < 20000; i++) {
             set.add(i);
         }
 
         Assert.assertTrue(set.retainAll(Arrays.asList(1, 2)));
+        Assert.assertThat(set, Matchers.containsInAnyOrder(1, 2));
         Assert.assertEquals(2, set.size());
     }
+
+//    @Test
+//    public void testIteratorRemoveHighVolume() {
+//        Set<Integer> set = redisson.getSet("set") /*new HashSet<Integer>()*/;
+//        for (int i = 0; i < 120000; i++) {
+//            set.add(i);
+//        }
+//        int cnt = 0;
+//        Iterator<Integer> iterator = set.iterator();
+//        while (iterator.hasNext()) {
+//            Integer integer = iterator.next();
+//            if (integer > -1) { // always
+//                iterator.remove();
+//            }
+//            cnt++;
+//        }
+//        System.out.println("-----------");
+//        for (Integer integer : set) {
+//            System.out.println(integer);
+//        }
+//        Assert.assertEquals(20000, cnt);
+//    }
 
     @Test
     public void testContainsAll() {
@@ -234,4 +252,27 @@ public class RedissonSetTest extends BaseTest {
         Assert.assertEquals(5, set.size());
     }
 
+
+    @Test
+    public void testRetainAllEmpty() {
+        Set<Integer> set = redisson.getSet("set");
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        set.add(5);
+
+        Assert.assertTrue(set.retainAll(Collections.<Integer>emptyList()));
+        Assert.assertEquals(0, set.size());
+    }
+
+    @Test
+    public void testRetainAllNoModify() {
+        Set<Integer> set = redisson.getSet("set");
+        set.add(1);
+        set.add(2);
+
+        Assert.assertFalse(set.retainAll(Arrays.asList(1, 2))); // nothing changed
+        Assert.assertThat(set, Matchers.containsInAnyOrder(1, 2));
+    }
 }

--- a/src/test/java/org/redisson/RedissonTopicTest.java
+++ b/src/test/java/org/redisson/RedissonTopicTest.java
@@ -1,5 +1,6 @@
 package org.redisson;
 
+import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Assert;
@@ -9,7 +10,7 @@ import org.redisson.core.RTopic;
 
 public class RedissonTopicTest {
 
-    public static class Message {
+    public static class Message implements Serializable {
 
         private String name;
 
@@ -47,7 +48,7 @@ public class RedissonTopicTest {
     public void testUnsubscribe() throws InterruptedException {
         final CountDownLatch messageRecieved = new CountDownLatch(1);
 
-        Redisson redisson = Redisson.create();
+        Redisson redisson = BaseTest.createInstance();
         RTopic<Message> topic1 = redisson.getTopic("topic1");
         int listenerId = topic1.addListener(new MessageListener<Message>() {
             @Override
@@ -77,7 +78,7 @@ public class RedissonTopicTest {
     public void testLazyUnsubscribe() throws InterruptedException {
         final CountDownLatch messageRecieved = new CountDownLatch(1);
 
-        Redisson redisson1 = Redisson.create();
+        Redisson redisson1 = BaseTest.createInstance();
         RTopic<Message> topic1 = redisson1.getTopic("topic");
         int listenerId = topic1.addListener(new MessageListener<Message>() {
             @Override
@@ -89,7 +90,7 @@ public class RedissonTopicTest {
         topic1.removeListener(listenerId);
         Thread.sleep(1000);
 
-        Redisson redisson2 = Redisson.create();
+        Redisson redisson2 = BaseTest.createInstance();
         RTopic<Message> topic2 = redisson2.getTopic("topic");
         topic2.addListener(new MessageListener<Message>() {
             @Override
@@ -111,7 +112,7 @@ public class RedissonTopicTest {
     public void test() throws InterruptedException {
         final CountDownLatch messageRecieved = new CountDownLatch(2);
 
-        Redisson redisson1 = Redisson.create();
+        Redisson redisson1 = BaseTest.createInstance();
         RTopic<Message> topic1 = redisson1.getTopic("topic");
         topic1.addListener(new MessageListener<Message>() {
             @Override
@@ -121,7 +122,7 @@ public class RedissonTopicTest {
             }
         });
 
-        Redisson redisson2 = Redisson.create();
+        Redisson redisson2 = BaseTest.createInstance();
         RTopic<Message> topic2 = redisson2.getTopic("topic");
         topic2.addListener(new MessageListener<Message>() {
             @Override
@@ -140,7 +141,7 @@ public class RedissonTopicTest {
 
     @Test
     public void testListenerRemove() throws InterruptedException {
-        Redisson redisson1 = Redisson.create();
+        Redisson redisson1 = BaseTest.createInstance();
         RTopic<Message> topic1 = redisson1.getTopic("topic");
         int id = topic1.addListener(new MessageListener<Message>() {
             @Override
@@ -149,7 +150,7 @@ public class RedissonTopicTest {
             }
         });
 
-        Redisson redisson2 = Redisson.create();
+        Redisson redisson2 = BaseTest.createInstance();
         RTopic<Message> topic2 = redisson2.getTopic("topic");
         topic1.removeListener(id);
         topic2.publish(new Message("123"));

--- a/src/test/java/org/redisson/TestObject.java
+++ b/src/test/java/org/redisson/TestObject.java
@@ -1,6 +1,8 @@
 package org.redisson;
 
-public class TestObject implements Comparable<TestObject> {
+import java.io.Serializable;
+
+public class TestObject implements Comparable<TestObject>, Serializable {
 
     private String name;
     private String value;


### PR DESCRIPTION
A Redis script is transactional by definition, so everything you can do with a Redis transaction, you can also do with a script, and usually the script will be both simpler and faster. http://redis.io/topics/transactions

PR includes 
 - solution for #100 (automatic locks expiration)
 - additional command output handlers required for scripts
 - number of fixes in codecs and codec usages
 - changes in tests to allow easy redis server location setup
 - bugfix for timeout configuration in RedisClient introduced in commit e923b269a2fdb352c7baae195726295e20a97b9b