### PR TITLE
Add clientName to MasterSlaveServersConfig in SentinelConnectionManager

### DIFF
--- a/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -60,6 +60,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         c.setLoadBalancer(cfg.getLoadBalancer());
         c.setPassword(cfg.getPassword());
         c.setDatabase(cfg.getDatabase());
+        c.setClientName(cfg.getClientName());
         c.setMasterConnectionPoolSize(cfg.getMasterConnectionPoolSize());
         c.setSlaveConnectionPoolSize(cfg.getSlaveConnectionPoolSize());
         c.setSlaveSubscriptionConnectionPoolSize(cfg.getSlaveSubscriptionConnectionPoolSize());


### PR DESCRIPTION
Fixes what I mentioned in this comment: https://github.com/mrniko/redisson/issues/198#issuecomment-134493830
Checked through `client list` in redis-cli and it works