### PR TITLE
DNS monitoring for SingleServerConnection

### DIFF
--- a/src/main/java/org/redisson/SingleServerConfig.java
+++ b/src/main/java/org/redisson/SingleServerConfig.java
@@ -38,6 +38,21 @@ public class SingleServerConfig extends BaseConfig<SingleServerConfig> {
      */
     private int connectionPoolSize = 100;
 
+        
+    /**
+     * Should the server address be monitored for changes in DNS? Useful for 
+     * AWS ElastiCache where the client is pointed at the endpoint for a replication group
+     * which is a DNS alias to the current master node.<br>
+     * <em>NB: applications must ensure the JVM DNS cache TTL is low enough to support this.</em> 
+     * e.g., http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-jvm-ttl.html
+     */
+    private boolean dnsMonitoring = false;
+
+    /**
+     * Interval in milliseconds to check DNS
+     */
+    private long dnsMonitoringInterval = 5000;
+    
     SingleServerConfig() {
     }
 
@@ -46,6 +61,8 @@ public class SingleServerConfig extends BaseConfig<SingleServerConfig> {
         setAddress(config.getAddress());
         setConnectionPoolSize(config.getConnectionPoolSize());
         setSubscriptionConnectionPoolSize(config.getSubscriptionConnectionPoolSize());
+        setDnsMonitoring(config.isDnsMonitoring());
+        setDnsMonitoringInterval(config.getDnsMonitoringInterval());
     }
 
     /**
@@ -93,4 +110,33 @@ public class SingleServerConfig extends BaseConfig<SingleServerConfig> {
         this.address = address;
     }
 
+    /**
+     * Monitoring of the endpoint address for DNS changes.
+     * Default is false.
+     * 
+     * @param dnsMonitoring
+     * @return
+     */
+    public SingleServerConfig setDnsMonitoring(boolean dnsMonitoring) {
+        this.dnsMonitoring = dnsMonitoring;
+        return this;
+    }
+    public boolean isDnsMonitoring() {
+        return dnsMonitoring;
+    }
+
+    /**
+     * Interval in milliseconds to check the endpoint DNS if {@link #isDnsMonitoring()} is true.
+     * Default is 5000.
+     * 
+     * @param dnsMonitoringInterval
+     * @return
+     */
+    public SingleServerConfig setDnsMonitoringInterval(long dnsMonitoringInterval) {
+        this.dnsMonitoringInterval = dnsMonitoringInterval;
+        return this;
+    }
+    public long getDnsMonitoringInterval() {
+        return dnsMonitoringInterval;
+    }
 }


### PR DESCRIPTION
With AWS ElastiCache replication groups there is no autodiscovery of nodes or in-client notification of failovers. Instead Elasticache changes the primary endpoint DNS to point to the newly promoted master. This leads to issues like https://github.com/mrniko/redisson/issues/241

This change allows monitoring of the endpoint to see if the underlying host address has changed. If it has changed, `changeMaster()` is invoked to shutdown the old client and start a new one.

Example code for testing:

```java
    public static void main(String[] args) {
        // must ensure the JVM isn't caching DNS lookups
        java.security.Security.setProperty("networkaddress.cache.ttl", "1");
        Config config = new Config();
        config.useSingleServer().setAddress(args[0]).setDnsMonitoring(true);
        Redisson r = Redisson.create(config);
        RAtomicLong al = r.getAtomicLong("testLong");
        while (true) {
            try {
                System.out.println(System.currentTimeMillis() +":"+ al.addAndGet(1));
            } catch (Throwable t) {
                System.out.println("Exception: " + t);
                t.printStackTrace(System.out);
            }
            try {
                Thread.sleep(1000);
            } catch (InterruptedException ignored) {}
        }
        
    }
```

example output, slave node is promoted while program runs:
```
1441910645627:372
1441910646632:373
1441910647635:374
1441910648638:375
Exception: org.redisson.client.RedisException: READONLY You can't write against a read only slave.. channel: [id: 0x3fddcec0, /10.0.x.x:52894 => foo.xxxxx.ng.0001.use1.cache.amazonaws.com/10.0.y.y:6379] command: CommandData [promise=DefaultPromise@6c65b2aa(incomplete), command=RedisCommand [name=INCRBY, subName=null], params=[testLong, 1], codec=org.redisson.client.codec.StringCodec@22341d23]
org.redisson.client.RedisException: READONLY You can't write against a read only slave.. channel: [id: 0x3fddcec0, /10.0.x.x:52894 => foo.xxxxx.ng.0001.use1.cache.amazonaws.com/10.0.y.y:6379] command: CommandData [promise=DefaultPromise@6c65b2aa(incomplete), command=RedisCommand [name=INCRBY, subName=null], params=[testLong, 1], codec=org.redisson.client.codec.StringCodec@22341d23]
	at org.redisson.client.handler.CommandDecoder.decode(CommandDecoder.java:168)
	at org.redisson.client.handler.CommandDecoder.decode(CommandDecoder.java:104)
...
[globalEventExecutor-1-1] INFO org.redisson.connection.SingleConnectionManager - Detected DNS change. foo.xxxxx.ng.0001.use1.cache.amazonaws.com has changed from 10.0.y.y to 10.0.z.z
[globalEventExecutor-1-1] INFO org.redisson.connection.SingleConnectionManager - Master has been changed
1441910725723:376
1441910726726:377
