### PR TITLE
Make the iterator method public

### DIFF
--- a/src/main/java/org/redisson/RedissonMap.java
+++ b/src/main/java/org/redisson/RedissonMap.java
@@ -286,7 +286,7 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
         return commandExecutor.read(client, getName(), codec, RedisCommands.HSCAN, getName(), startPos);
     }
 
-    private Iterator<Map.Entry<K, V>> iterator() {
+    public Iterator<Map.Entry<K, V>> iterator() {
         return new Iterator<Map.Entry<K, V>>() {
 
             private Iterator<Map.Entry<K, V>> iter;


### PR DESCRIPTION
The `iterator` method in RedissonSet is public. It would be useful to make the RedissonMap iterator public, too, enabling iteration over hashes with millions of keys without memory issues.