### PR TITLE
fix "diamond operator is not supported in -source 1.6" error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
 
     <properties>
         <maven.test.skip>true</maven.test.skip>
+        <source.version>1.6</source.version>
+        <test.source.version>1.8</test.source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -281,7 +283,7 @@
                 <configuration>
                     <linkXref>true</linkXref>
                     <minimumTokens>100</minimumTokens>
-                    <targetJdk>1.6</targetJdk>
+                    <targetJdk>${source.version}</targetJdk>
                     <verbose>true</verbose>
                 </configuration>
             </plugin>
@@ -309,8 +311,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${source.version}</source>
+                    <target>${source.version}</target>
                     <optimize>true</optimize>
                     <showDeprecations>true</showDeprecations>
                 </configuration>
@@ -323,10 +325,8 @@
                         </goals>
                         <configuration>
                             <fork>true</fork>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <optimize>true</optimize>
-                            <showDeprecations>true</showDeprecations>
+                            <source>${test.source.version}</source>
+                            <target>${test.source.version}</target>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>unit-test</id>
+            <properties>
+                <maven.test.skip>false</maven.test.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/src/main/java/org/redisson/reactive/RedissonMapReactive.java
+++ b/src/main/java/org/redisson/reactive/RedissonMapReactive.java
@@ -50,12 +50,12 @@ public class RedissonMapReactive<K, V> extends RedissonExpirableReactive impleme
 
     public RedissonMapReactive(CommandReactiveExecutor commandExecutor, String name) {
         super(commandExecutor, name);
-        instance = new RedissonMap<>(codec, commandExecutor, name);
+        instance = new RedissonMap<K, V>(codec, commandExecutor, name);
     }
 
     public RedissonMapReactive(Codec codec, CommandReactiveExecutor commandExecutor, String name) {
         super(codec, commandExecutor, name);
-        instance = new RedissonMap<>(codec, commandExecutor, name);
+        instance = new RedissonMap<K, V>(codec, commandExecutor, name);
     }
 
     @Override


### PR DESCRIPTION
Generic type is added back in since the diamond operator "<>" is only available for source version 7 or above.

See:
https://docs.oracle.com/javase/tutorial/java/generics/types.html#diamond