### PR TITLE
Add DynamicImport-Package to OSGi headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
If you cache domain models (i.e. via the Serialization-Codec) within an
OSGi-environment and want to retrieve those back you will hit
ClassNotFoundException as the Redis-Bundle doesn't import the
appropriate packages. One way to avoid this would be the additional
"<DynamicImport-Package>*</DynamicImport-Package>" declaration for the
OSGi headers,

FIXES #410