### PR TITLE
Stop HashedWheelTimer after exception in constructor

### DIFF
--- a/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
+++ b/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
@@ -96,11 +96,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
         }
 
         if (lastPartitions.isEmpty()) {
-            try {
-                group.shutdownGracefully().await();
-            } catch (Exception e) {
-                // skip it
-            }
+            stopThreads();
             throw new RedisConnectionException("Can't connect to servers!", lastException);
         }
 

--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -202,11 +202,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         try {
             initEntry(config);
         } catch (RuntimeException e) {
-            try {
-                group.shutdownGracefully().await();
-            } catch (Exception e1) {
-                // skip
-            }
+            stopThreads();
             throw e;
         }
     }
@@ -741,4 +737,12 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         return connectionEventsHub;
     }
 
+    protected void stopThreads() {
+        timer.stop();
+        try {
+            group.shutdownGracefully().await();
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
 }


### PR DESCRIPTION
When connection error occurs in `{MasterSlave,Cluster}ConnectionManager` constructor, `HashedWheelTimer` is not stopped, which leaves its thread running until application is killed.