### PR TITLE
Untie tests from Windows absolute paths

### DIFF
--- a/src/test/java/org/redisson/RedisRunner.java
+++ b/src/test/java/org/redisson/RedisRunner.java
@@ -1,22 +1,77 @@
 package org.redisson;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.*;
+import java.util.Objects;
 
 public class RedisRunner {
 
-    private static final String redisFolder = "C:\\Devel\\projects\\redis\\Redis-x64-3.0.500\\";
+    public static final int REDIS_EXIT_CODE;
+
+    private static final String defaultRedisDirectory = "C:\\Devel\\projects\\redis\\Redis-x64-3.0.500\\";
+    private static final String defaultRedisExecutable = defaultRedisDirectory + "redis-server.exe";
+    private static final String redisExecutable;
+
+    static {
+        String path = System.getenv("PATH");
+        if (path != null) {
+            String os = System.getProperty("os.name");
+            String pathSeparator = ":";
+            String executableName = "redis-server";
+            if (os.toLowerCase().startsWith("windows")) {
+                pathSeparator = ";";
+                executableName = "redis-server.exe";
+                REDIS_EXIT_CODE = 1;
+            } else {
+                REDIS_EXIT_CODE = 0;
+            }
+
+            String[] pathEntries = path.split(pathSeparator);
+            Path fullExecutablePath = null;
+            for (String pathEntry : pathEntries) {
+                fullExecutablePath = Paths.get(pathEntry, executableName);
+                if (Files.exists(fullExecutablePath)) {
+                    break;
+                }
+            }
+
+            if (fullExecutablePath != null) {
+                redisExecutable = fullExecutablePath.toString();
+            } else {
+                redisExecutable = defaultRedisExecutable;
+            }
+        } else {
+            redisExecutable = defaultRedisExecutable;
+            REDIS_EXIT_CODE = 1;
+        }
+
+        if (!new File(redisExecutable).exists()) {
+            throw new RuntimeException("Redis executable not found");
+        }
+    }
 
     public static Process runRedis(String configPath) throws IOException, InterruptedException {
         URL resource = RedisRunner.class.getResource(configPath);
+        String fullConfigPath = Paths.get(resource.getFile()).toAbsolutePath().toString();
 
-        ProcessBuilder master = new ProcessBuilder(redisFolder + "redis-server.exe", resource.getFile().substring(1));
-        master.directory(new File(redisFolder));
+        ProcessBuilder master = new ProcessBuilder(redisExecutable, fullConfigPath, "--dir", getWorkingDirectory());
+        master.directory(new File(getWorkingDirectory()));
         Process p = master.start();
         Thread.sleep(1000);
+
+        if (!p.isAlive()) {
+            throw new RuntimeException("Redis executable stopped with exit code " + p.exitValue());
+        }
+
         return p;
     }
 
-
+    private static String getWorkingDirectory() {
+        if (redisExecutable.equals(defaultRedisExecutable)) {
+            return defaultRedisDirectory;
+        }
+        return System.getProperty("user.dir");
+    }
 }

--- a/src/test/java/org/redisson/RedissonMultiLockTest.java
+++ b/src/test/java/org/redisson/RedissonMultiLockTest.java
@@ -66,13 +66,13 @@ public class RedissonMultiLockTest {
         lock.unlock();
 
         redis1.destroy();
-        assertThat(redis1.waitFor()).isEqualTo(1);
+        assertThat(redis1.waitFor()).isEqualTo(RedisRunner.REDIS_EXIT_CODE);
 
         redis2.destroy();
-        assertThat(redis2.waitFor()).isEqualTo(1);
+        assertThat(redis2.waitFor()).isEqualTo(RedisRunner.REDIS_EXIT_CODE);
 
         redis3.destroy();
-        assertThat(redis3.waitFor()).isEqualTo(1);
+        assertThat(redis3.waitFor()).isEqualTo(RedisRunner.REDIS_EXIT_CODE);
     }
 
 }

--- a/src/test/java/org/redisson/RedissonTest.java
+++ b/src/test/java/org/redisson/RedissonTest.java
@@ -127,7 +127,7 @@ public class RedissonTest {
 
         r.getBucket("1").get();
         p.destroy();
-        Assert.assertEquals(1, p.waitFor());
+        Assert.assertEquals(RedisRunner.REDIS_EXIT_CODE, p.waitFor());
 
         try {
             r.getBucket("1").get();
@@ -141,7 +141,7 @@ public class RedissonTest {
         r.shutdown();
 
         p.destroy();
-        Assert.assertEquals(1, p.waitFor());
+        Assert.assertEquals(RedisRunner.REDIS_EXIT_CODE, p.waitFor());
 
         await().atMost(1, TimeUnit.SECONDS).until(() -> assertThat(connectCounter.get()).isEqualTo(2));
         await().until(() -> assertThat(disconnectCounter.get()).isEqualTo(1));

--- a/src/test/resources/redis_connectionListener_test.conf
+++ b/src/test/resources/redis_connectionListener_test.conf
@@ -150,7 +150,7 @@ rdbchecksum yes
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir "C:\\Devel\\projects\\redis"
+# dir "C:\\Devel\\projects\\redis"
 
 ################################# REPLICATION #################################
 

--- a/src/test/resources/redis_multiLock_test_instance1.conf
+++ b/src/test/resources/redis_multiLock_test_instance1.conf
@@ -150,7 +150,7 @@ rdbchecksum yes
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir "C:\\Devel\\projects\\redis"
+# dir "C:\\Devel\\projects\\redis"
 
 ################################# REPLICATION #################################
 

--- a/src/test/resources/redis_multiLock_test_instance2.conf
+++ b/src/test/resources/redis_multiLock_test_instance2.conf
@@ -150,7 +150,7 @@ rdbchecksum yes
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir "C:\\Devel\\projects\\redis"
+# dir "C:\\Devel\\projects\\redis"
 
 ################################# REPLICATION #################################
 

--- a/src/test/resources/redis_multiLock_test_instance3.conf
+++ b/src/test/resources/redis_multiLock_test_instance3.conf
@@ -150,7 +150,7 @@ rdbchecksum yes
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir "C:\\Devel\\projects\\redis"
+# dir "C:\\Devel\\projects\\redis"
 
 ################################# REPLICATION #################################
 

--- a/src/test/resources/redis_oom_test.conf
+++ b/src/test/resources/redis_oom_test.conf
@@ -150,7 +150,7 @@ rdbchecksum yes
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir "C:\\Devel\\projects\\redis"
+# dir "C:\\Devel\\projects\\redis"
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
Currently tests are bound to a certain setup on Windows.
This PR enables running them on Linux and Mac OS X with discovering redis-server executable in PATH, saving behavior for your environment.