### PR TITLE
Fixed removeAll bug in RedissonSet

### DIFF
--- a/src/main/java/org/redisson/RedissonSet.java
+++ b/src/main/java/org/redisson/RedissonSet.java
@@ -229,7 +229,7 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V> {
         args.add(getName());
         args.addAll(c);
         
-        return commandExecutor.writeAsync(getName(), codec, RedisCommands.SREM_SINGLE, c.toArray());
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.SREM_SINGLE, args.toArray());
     }
 
     @Override


### PR DESCRIPTION
In removeAll method, wrong list was passed to the command executor.