### PR TITLE
proof of concept for unacknowledged and/or fire-and-forget calls in RRemoteService

### DIFF
--- a/src/main/java/org/redisson/core/RRemoteService.java
+++ b/src/main/java/org/redisson/core/RRemoteService.java
@@ -91,7 +91,9 @@ public interface RRemoteService {
      * with specified invocation timeout.
      * <p/> 
      * Ack timeout = 1000 ms by default
-     * 
+     * <p/>
+     * A negative executionTimeout will make fire-and-forget calls
+     *
      * @param remoteInterface
      * @param executionTimeout - invocation timeout
      * @param executionTimeUnit
@@ -102,7 +104,11 @@ public interface RRemoteService {
     /**
      * Get remote service object for remote invocations
      * with specified invocation and ack timeouts
-     * 
+     * <p/>
+     * A negative executionTimeout will make fire-and-forget calls
+     * <p/>
+     * A negative ackTimeout will make unacknowledged calls
+     *
      * @param remoteInterface
      * @param executionTimeout - invocation timeout
      * @param executionTimeUnit

--- a/src/main/java/org/redisson/core/RRemoteService.java
+++ b/src/main/java/org/redisson/core/RRemoteService.java
@@ -77,22 +77,31 @@ public interface RRemoteService {
     /**
      * Get remote service object for remote invocations.
      * <p/>
-     * Ack timeout = 1000 ms by default
-     * <p/>
-     * Execution timeout = 30 sec by default
-     * 
+     * This method is a shortcut for
+     * <pre>
+     *     get(remoteInterface, RemoteInvocationOptions.defaults())
+     * </pre>
+     *
+     * @see RemoteInvocationOptions#defaults()
+     * @see #get(Class, RemoteInvocationOptions)
+     *
      * @param remoteInterface
      * @return
      */
     <T> T get(Class<T> remoteInterface);
-    
+
     /**
      * Get remote service object for remote invocations 
      * with specified invocation timeout.
-     * <p/> 
-     * Ack timeout = 1000 ms by default
      * <p/>
-     * A negative executionTimeout will make fire-and-forget calls
+     * This method is a shortcut for
+     * <pre>
+     *     get(remoteInterface, RemoteInvocationOptions.defaults()
+     *      .expectResultWithin(executionTimeout, executionTimeUnit))
+     * </pre>
+     *
+     * @see RemoteInvocationOptions#defaults()
+     * @see #get(Class, RemoteInvocationOptions)
      *
      * @param remoteInterface
      * @param executionTimeout - invocation timeout
@@ -105,9 +114,15 @@ public interface RRemoteService {
      * Get remote service object for remote invocations
      * with specified invocation and ack timeouts
      * <p/>
-     * A negative executionTimeout will make fire-and-forget calls
-     * <p/>
-     * A negative ackTimeout will make unacknowledged calls
+     * This method is a shortcut for
+     * <pre>
+     *     get(remoteInterface, RemoteInvocationOptions.defaults()
+     *      .expectAckWithin(ackTimeout, ackTimeUnit)
+     *      .expectResultWithin(executionTimeout, executionTimeUnit))
+     * </pre>
+     *
+     * @see RemoteInvocationOptions
+     * @see #get(Class, RemoteInvocationOptions)
      *
      * @param remoteInterface
      * @param executionTimeout - invocation timeout
@@ -117,5 +132,17 @@ public interface RRemoteService {
      * @return
      */
     <T> T get(Class<T> remoteInterface, long executionTimeout, TimeUnit executionTimeUnit, long ackTimeout, TimeUnit ackTimeUnit);
-    
+
+    /**
+     * Get remote service object for remote invocations
+     * with the specified options
+     * <p/>
+     * Note that when using the noResult() option,
+     * it is expected that the invoked method returns void,
+     * or else IllegalArgumentException will be thrown.
+     *
+     * @see RemoteInvocationOptions
+     */
+    <T> T get(Class<T> remoteInterface, RemoteInvocationOptions options);
+
 }

--- a/src/main/java/org/redisson/core/RemoteInvocationOptions.java
+++ b/src/main/java/org/redisson/core/RemoteInvocationOptions.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2014 Nikita Koksharov, Nickolay Borbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.core;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RRemoteService invocation options.
+ *
+ * Used to tune how RRemoteService will behave
+ * in regard to the remote invocations acknowledgement
+ * and execution timeout.
+ * <p/>
+ * Examples:
+ * <pre>
+ *     // 1 second ack timeout and 30 seconds execution timeout
+ *     RemoteInvocationOptions options =
+ *          RemoteInvocationOptions.defaults();
+ *
+ *     // no ack but 30 seconds execution timeout
+ *     RemoteInvocationOptions options =
+ *          RemoteInvocationOptions.defaults()
+ *              .noAck();
+ *
+ *     // 1 second ack timeout then forget the result
+ *     RemoteInvocationOptions options =
+ *          RemoteInvocationOptions.defaults()
+ *              .noResult();
+ *
+ *     // 1 minute ack timeout then forget about the result
+ *     RemoteInvocationOptions options =
+ *          RemoteInvocationOptions.defaults()
+ *              .expectAckWithin(1, TimeUnit.MINUTES)
+ *              .noResult();
+ *
+ *     // no ack and forget about the result (fire and forget)
+ *     RemoteInvocationOptions options =
+ *          RemoteInvocationOptions.defaults()
+ *              .noAck()
+ *              .noResult();
+ * </pre>
+ *
+ * @see RRemoteService#get(Class, RemoteInvocationOptions)
+ */
+public class RemoteInvocationOptions {
+
+    private Long ackTimeoutInMillis;
+    private Long executionTimeoutInMillis;
+
+    private RemoteInvocationOptions(Long ackTimeoutInMillis, Long executionTimeoutInMillis) {
+        this.ackTimeoutInMillis = ackTimeoutInMillis;
+        this.executionTimeoutInMillis = executionTimeoutInMillis;
+    }
+
+    /**
+     * Creates a new instance of RemoteInvocationOptions with opinionated defaults.
+     * <p/>
+     * This is equivalent to:
+     * <pre>
+     *     RemoteInvocationOptions.defaults()
+     *      .expectAckWithin(1, TimeUnit.SECONDS)
+     *      .expectResultWithin(30, TimeUnit.SECONDS)
+     * </pre>
+     */
+    public static RemoteInvocationOptions defaults() {
+        return new RemoteInvocationOptions(TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toMillis(30));
+    }
+
+    public Long getAckTimeoutInMillis() {
+        return ackTimeoutInMillis;
+    }
+
+    public Long getExecutionTimeoutInMillis() {
+        return executionTimeoutInMillis;
+    }
+
+    public boolean isAckExpected() {
+        return ackTimeoutInMillis != null;
+    }
+
+    public boolean isResultExpected() {
+        return executionTimeoutInMillis != null;
+    }
+
+    public RemoteInvocationOptions expectAckWithin(long ackTimeoutInMillis) {
+        this.ackTimeoutInMillis = ackTimeoutInMillis;
+        return this;
+    }
+
+    public RemoteInvocationOptions expectAckWithin(long ackTimeout, TimeUnit timeUnit) {
+        this.ackTimeoutInMillis = timeUnit.toMillis(ackTimeout);
+        return this;
+    }
+
+    public RemoteInvocationOptions noAck() {
+        ackTimeoutInMillis = null;
+        return this;
+    }
+
+    public RemoteInvocationOptions expectResultWithin(long executionTimeoutInMillis) {
+        this.executionTimeoutInMillis = executionTimeoutInMillis;
+        return this;
+    }
+
+    public RemoteInvocationOptions expectResultWithin(long executionTimeout, TimeUnit timeUnit) {
+        this.executionTimeoutInMillis = timeUnit.toMillis(executionTimeout);
+        return this;
+    }
+
+    public RemoteInvocationOptions noResult() {
+        executionTimeoutInMillis = null;
+        return this;
+    }
+}

--- a/src/main/java/org/redisson/core/RemoteInvocationOptions.java
+++ b/src/main/java/org/redisson/core/RemoteInvocationOptions.java
@@ -65,6 +65,11 @@ public class RemoteInvocationOptions {
         this.executionTimeoutInMillis = executionTimeoutInMillis;
     }
 
+    public RemoteInvocationOptions(RemoteInvocationOptions copy) {
+        this.ackTimeoutInMillis = copy.ackTimeoutInMillis;
+        this.executionTimeoutInMillis = copy.executionTimeoutInMillis;
+    }
+
     /**
      * Creates a new instance of RemoteInvocationOptions with opinionated defaults.
      * <p/>

--- a/src/main/java/org/redisson/core/RemoteInvocationOptions.java
+++ b/src/main/java/org/redisson/core/RemoteInvocationOptions.java
@@ -15,6 +15,7 @@
  */
 package org.redisson.core;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,14 +56,12 @@ import java.util.concurrent.TimeUnit;
  *
  * @see RRemoteService#get(Class, RemoteInvocationOptions)
  */
-public class RemoteInvocationOptions {
+public class RemoteInvocationOptions implements Serializable {
 
     private Long ackTimeoutInMillis;
     private Long executionTimeoutInMillis;
 
-    private RemoteInvocationOptions(Long ackTimeoutInMillis, Long executionTimeoutInMillis) {
-        this.ackTimeoutInMillis = ackTimeoutInMillis;
-        this.executionTimeoutInMillis = executionTimeoutInMillis;
+    private RemoteInvocationOptions() {
     }
 
     public RemoteInvocationOptions(RemoteInvocationOptions copy) {
@@ -75,13 +74,15 @@ public class RemoteInvocationOptions {
      * <p/>
      * This is equivalent to:
      * <pre>
-     *     RemoteInvocationOptions.defaults()
+     *     new RemoteInvocationOptions()
      *      .expectAckWithin(1, TimeUnit.SECONDS)
      *      .expectResultWithin(30, TimeUnit.SECONDS)
      * </pre>
      */
     public static RemoteInvocationOptions defaults() {
-        return new RemoteInvocationOptions(TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toMillis(30));
+        return new RemoteInvocationOptions()
+                .expectAckWithin(1, TimeUnit.SECONDS)
+                .expectResultWithin(20, TimeUnit.SECONDS);
     }
 
     public Long getAckTimeoutInMillis() {
@@ -128,5 +129,13 @@ public class RemoteInvocationOptions {
     public RemoteInvocationOptions noResult() {
         executionTimeoutInMillis = null;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteInvocationOptions[" +
+                "ackTimeoutInMillis=" + ackTimeoutInMillis +
+                ", executionTimeoutInMillis=" + executionTimeoutInMillis +
+                ']';
     }
 }

--- a/src/main/java/org/redisson/remote/RemoteServiceRequest.java
+++ b/src/main/java/org/redisson/remote/RemoteServiceRequest.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.remote;
 
+import org.redisson.core.RemoteInvocationOptions;
+
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -23,34 +25,24 @@ public class RemoteServiceRequest implements Serializable {
     private String requestId;
     private String methodName;
     private Object[] args;
-    private long ackTimeout;
-    private long responseTimeout;
+    private RemoteInvocationOptions options;
     private long date;
     
     
     public RemoteServiceRequest() {
     }
     
-    public RemoteServiceRequest(String requestId, String methodName, Object[] args, long ackTimeout, long responseTimeout, long date) {
+    public RemoteServiceRequest(String requestId, String methodName, Object[] args, RemoteInvocationOptions options, long date) {
         super();
         this.requestId = requestId;
         this.methodName = methodName;
         this.args = args;
-        this.ackTimeout = ackTimeout;
-        this.responseTimeout = responseTimeout;
+        this.options = options;
         this.date = date;
-    }
-    
-    public long getResponseTimeout() {
-        return responseTimeout;
     }
     
     public long getDate() {
         return date;
-    }
-    
-    public long getAckTimeout() {
-        return ackTimeout;
     }
     
     public String getRequestId() {
@@ -60,7 +52,11 @@ public class RemoteServiceRequest implements Serializable {
     public Object[] getArgs() {
         return args;
     }
-    
+
+    public RemoteInvocationOptions getOptions() {
+        return options;
+    }
+
     public String getMethodName() {
         return methodName;
     }
@@ -68,7 +64,7 @@ public class RemoteServiceRequest implements Serializable {
     @Override
     public String toString() {
         return "RemoteServiceRequest [requestId=" + requestId + ", methodName=" + methodName + ", args="
-                + Arrays.toString(args) + ", ackTimeout=" + ackTimeout + ", date=" + date + "]";
+                + Arrays.toString(args) + ", options=" + options + ", date=" + date + "]";
     }
 
 }

--- a/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -383,135 +383,138 @@ public class RedissonRemoteServiceTest extends BaseTest {
     public void testNoAckWithResultInvocations() throws InterruptedException {
         RedissonClient server = Redisson.create();
         RedissonClient client = Redisson.create();
-
-        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
-
-        // no ack but an execution timeout of 1 second
-        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().expectResultWithin(1, TimeUnit.SECONDS);
-        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
-
-        service.voidMethod("noAck", 100L);
-        assertThat(service.resultMethod(21L)).isEqualTo(42);
-
         try {
-            service.errorMethod();
-            Assert.fail();
-        } catch (IOException e) {
-            assertThat(e.getMessage()).isEqualTo("Checking error throw");
-        }
+            server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
 
-        try {
-            service.errorMethodWithCause();
-            Assert.fail();
-        } catch (Exception e) {
-            assertThat(e.getCause()).isInstanceOf(ArithmeticException.class);
-            assertThat(e.getCause().getMessage()).isEqualTo("/ by zero");
-        }
+            // no ack but an execution timeout of 1 second
+            RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().expectResultWithin(1, TimeUnit.SECONDS);
+            RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
 
-        try {
-            service.timeoutMethod();
-            Assert.fail("noAck option should still wait for the server to return a response and throw if the execution timeout is exceeded");
-        } catch (Exception e) {
-            assertThat(e).isInstanceOf(RemoteServiceTimeoutException.class);
-        }
+            service.voidMethod("noAck", 100L);
+            assertThat(service.resultMethod(21L)).isEqualTo(42);
 
-        client.shutdown();
-        server.shutdown();
+            try {
+                service.errorMethod();
+                Assert.fail();
+            } catch (IOException e) {
+                assertThat(e.getMessage()).isEqualTo("Checking error throw");
+            }
+
+            try {
+                service.errorMethodWithCause();
+                Assert.fail();
+            } catch (Exception e) {
+                assertThat(e.getCause()).isInstanceOf(ArithmeticException.class);
+                assertThat(e.getCause().getMessage()).isEqualTo("/ by zero");
+            }
+
+            try {
+                service.timeoutMethod();
+                Assert.fail("noAck option should still wait for the server to return a response and throw if the execution timeout is exceeded");
+            } catch (Exception e) {
+                assertThat(e).isInstanceOf(RemoteServiceTimeoutException.class);
+            }
+        } finally {
+            client.shutdown();
+            server.shutdown();
+        }
     }
 
     @Test
     public void testAckWithoutResultInvocations() throws InterruptedException {
         RedissonClient server = Redisson.create();
         RedissonClient client = Redisson.create();
-
-        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
-
-        // fire and forget with an ack timeout of 1 sec
-        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().expectAckWithin(1, TimeUnit.SECONDS).noResult();
-        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
-
-        service.voidMethod("noResult", 100L);
-
         try {
-            service.resultMethod(100L);
-            Assert.fail();
-        } catch (Exception e) {
-            assertThat(e).isInstanceOf(IllegalArgumentException.class);
-        }
+            server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
 
-        try {
-            service.errorMethod();
-        } catch (IOException e) {
-            Assert.fail("noResult option should not throw server side exception");
-        }
+            // fire and forget with an ack timeout of 1 sec
+            RemoteInvocationOptions options = RemoteInvocationOptions.defaults().expectAckWithin(1, TimeUnit.SECONDS).noResult();
+            RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
 
-        try {
-            service.errorMethodWithCause();
-        } catch (Exception e) {
-            Assert.fail("noResult option should not throw server side exception");
-        }
+            service.voidMethod("noResult", 100L);
 
-        long time = System.currentTimeMillis();
-        service.timeoutMethod();
-        time = System.currentTimeMillis() - time;
-        assertThat(time).describedAs("noResult option should not wait for the server to return a response").isLessThan(2000);
+            try {
+                service.resultMethod(100L);
+                Assert.fail();
+            } catch (Exception e) {
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
+            }
 
-        try {
+            try {
+                service.errorMethod();
+            } catch (IOException e) {
+                Assert.fail("noResult option should not throw server side exception");
+            }
+
+            try {
+                service.errorMethodWithCause();
+            } catch (Exception e) {
+                Assert.fail("noResult option should not throw server side exception");
+            }
+
+            long time = System.currentTimeMillis();
             service.timeoutMethod();
-            Assert.fail("noResult option should still wait for the server to ack the request and throw if the ack timeout is exceeded");
-        } catch (Exception e) {
-            assertThat(e).isInstanceOf(RemoteServiceAckTimeoutException.class);
-        }
+            time = System.currentTimeMillis() - time;
+            assertThat(time).describedAs("noResult option should not wait for the server to return a response").isLessThan(2000);
 
-        client.shutdown();
-        server.shutdown();
+            try {
+                service.timeoutMethod();
+                Assert.fail("noResult option should still wait for the server to ack the request and throw if the ack timeout is exceeded");
+            } catch (Exception e) {
+                assertThat(e).isInstanceOf(RemoteServiceAckTimeoutException.class);
+            }
+        } finally {
+            client.shutdown();
+            server.shutdown();
+        }
     }
 
     @Test
     public void testNoAckWithoutResultInvocations() throws InterruptedException {
         RedissonClient server = Redisson.create();
         RedissonClient client = Redisson.create();
-
-        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
-
-        // no ack fire and forget
-        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().noResult();
-        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
-        RemoteInterface invalidService = client.getRemoteSerivce("Invalid").get(RemoteInterface.class, options);
-
-        service.voidMethod("noAck/noResult", 100L);
-
         try {
-            service.resultMethod(100L);
-            Assert.fail();
-        } catch (Exception e) {
-            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+            server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
+
+            // no ack fire and forget
+            RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().noResult();
+            RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
+            RemoteInterface invalidService = client.getRemoteSerivce("Invalid").get(RemoteInterface.class, options);
+
+            service.voidMethod("noAck/noResult", 100L);
+
+            try {
+                service.resultMethod(100L);
+                Assert.fail();
+            } catch (Exception e) {
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
+            }
+
+            try {
+                service.errorMethod();
+            } catch (IOException e) {
+                Assert.fail("noAck with noResult options should not throw server side exception");
+            }
+
+            try {
+                service.errorMethodWithCause();
+            } catch (Exception e) {
+                Assert.fail("noAck with noResult options should not throw server side exception");
+            }
+
+            long time = System.currentTimeMillis();
+            service.timeoutMethod();
+            time = System.currentTimeMillis() - time;
+            assertThat(time).describedAs("noAck with noResult options should not wait for the server to return a response").isLessThan(2000);
+
+            try {
+                invalidService.voidMethod("noAck/noResult", 21L);
+            } catch (Exception e) {
+                Assert.fail("noAck with noResult options should not throw any exception even while invoking a service in an unregistered services namespace");
+            }
+        } finally {
+            client.shutdown();
+            server.shutdown();
         }
-
-        try {
-            service.errorMethod();
-        } catch (IOException e) {
-            Assert.fail("noAck with noResult options should not throw server side exception");
-        }
-
-        try {
-            service.errorMethodWithCause();
-        } catch (Exception e) {
-            Assert.fail("noAck with noResult options should not throw server side exception");
-        }
-
-        long time = System.currentTimeMillis();
-        service.timeoutMethod();
-        time = System.currentTimeMillis() - time;
-        assertThat(time).describedAs("noAck with noResult options should not wait for the server to return a response").isLessThan(2000);
-
-        try {
-            invalidService.voidMethod("noAck/noResult", 21L);
-        } catch (Exception e) {
-            Assert.fail("noAck with noResult options should not throw any exception even while invoking a service in an unregistered services namespace");
-        }
-
-        client.shutdown();
-        server.shutdown();
     }
 }

--- a/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.redisson.codec.FstCodec;
 import org.redisson.codec.SerializationCodec;
+import org.redisson.core.RemoteInvocationOptions;
+import org.redisson.remote.RemoteServiceAckTimeoutException;
 import org.redisson.remote.RemoteServiceTimeoutException;
 
 import java.io.IOException;
@@ -62,8 +64,6 @@ public class RedissonRemoteServiceTest extends BaseTest {
         
         void voidMethod(String name, Long param);
 
-        int primitiveMethod();
-        
         Long resultMethod(Long value);
         
         void errorMethod() throws IOException;
@@ -83,11 +83,6 @@ public class RedissonRemoteServiceTest extends BaseTest {
         @Override
         public void voidMethod(String name, Long param) {
             System.out.println(name + " " + param);
-        }
-
-        @Override
-        public int primitiveMethod() {
-            return 42;
         }
 
         @Override
@@ -255,19 +250,33 @@ public class RedissonRemoteServiceTest extends BaseTest {
 
     @Test
     public void testInvocationWithServiceName() {
-        String name = "MyServiceName";
+        RedissonClient server = Redisson.create();
+        RedissonClient client = Redisson.create();
 
-        RedissonClient r1 = Redisson.create();
-        r1.getRemoteSerivce(name).register(RemoteInterface.class, new RemoteImpl());
+        server.getRemoteSerivce("MyServiceNamespace").register(RemoteInterface.class, new RemoteImpl());
 
-        RedissonClient r2 = Redisson.create();
-        RemoteInterface ri = r2.getRemoteSerivce(name).get(RemoteInterface.class);
+        RemoteInterface serviceRemoteInterface = client.getRemoteSerivce("MyServiceNamespace").get(RemoteInterface.class);
+        RemoteInterface otherServiceRemoteInterface = client.getRemoteSerivce("MyOtherServiceNamespace").get(RemoteInterface.class);
+        RemoteInterface defaultServiceRemoteInterface = client.getRemoteSerivce().get(RemoteInterface.class);
 
-        ri.voidMethod("someName", 100L);
-        assertThat(ri.resultMethod(100L)).isEqualTo(200);
+        assertThat(serviceRemoteInterface.resultMethod(21L)).isEqualTo(42L);
 
-        r1.shutdown();
-        r2.shutdown();
+        try {
+            otherServiceRemoteInterface.resultMethod(21L);
+            Assert.fail("Invoking a service in an unregistered custom services namespace should throw");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RemoteServiceAckTimeoutException.class);
+        }
+
+        try {
+            defaultServiceRemoteInterface.resultMethod(21L);
+            Assert.fail("Invoking a service in the unregistered default services namespace should throw");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RemoteServiceAckTimeoutException.class);
+        }
+
+        client.shutdown();
+        server.shutdown();
     }
 
     @Test
@@ -371,73 +380,138 @@ public class RedissonRemoteServiceTest extends BaseTest {
     }
 
     @Test
-    public void testUnacknowledgedInvocations() throws InterruptedException {
-        RedissonClient r1 = Redisson.create();
-        r1.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
+    public void testNoAckWithResultInvocations() throws InterruptedException {
+        RedissonClient server = Redisson.create();
+        RedissonClient client = Redisson.create();
 
-        RedissonClient r2 = Redisson.create();
-        RemoteInterface ri = r2.getRemoteSerivce().get(RemoteInterface.class, 30, TimeUnit.SECONDS, -1, TimeUnit.SECONDS);
+        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
 
-        ri.voidMethod("someName", 100L);
-        assertThat(ri.resultMethod(100L)).isEqualTo(200);
+        // no ack but an execution timeout of 1 second
+        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().expectResultWithin(1, TimeUnit.SECONDS);
+        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
 
-        assertThat(ri.primitiveMethod()).isEqualTo(42);
+        service.voidMethod("noAck", 100L);
+        assertThat(service.resultMethod(21L)).isEqualTo(42);
 
         try {
-            ri.errorMethod();
+            service.errorMethod();
             Assert.fail();
         } catch (IOException e) {
             assertThat(e.getMessage()).isEqualTo("Checking error throw");
         }
 
         try {
-            ri.errorMethodWithCause();
+            service.errorMethodWithCause();
             Assert.fail();
         } catch (Exception e) {
             assertThat(e.getCause()).isInstanceOf(ArithmeticException.class);
             assertThat(e.getCause().getMessage()).isEqualTo("/ by zero");
         }
 
-        long time = System.currentTimeMillis();
-        ri.timeoutMethod();
-        time = System.currentTimeMillis() - time;
-        assertThat(time).describedAs("unacknowledged should still wait for the server to return a response").isGreaterThanOrEqualTo(2000);
+        try {
+            service.timeoutMethod();
+            Assert.fail("noAck option should still wait for the server to return a response and throw if the execution timeout is exceeded");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RemoteServiceTimeoutException.class);
+        }
 
-        r1.shutdown();
-        r2.shutdown();
+        client.shutdown();
+        server.shutdown();
     }
 
     @Test
-    public void testFireAndForgetInvocations() throws InterruptedException {
-        RedissonClient r1 = Redisson.create();
-        r1.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
+    public void testAckWithoutResultInvocations() throws InterruptedException {
+        RedissonClient server = Redisson.create();
+        RedissonClient client = Redisson.create();
 
-        RedissonClient r2 = Redisson.create();
-        RemoteInterface ri = r2.getRemoteSerivce().get(RemoteInterface.class, -1, TimeUnit.SECONDS);
+        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
 
-        ri.voidMethod("someName", 100L);
-        assertThat(ri.resultMethod(100L)).isNull();
+        // fire and forget with an ack timeout of 1 sec
+        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().expectAckWithin(1, TimeUnit.SECONDS).noResult();
+        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
 
-        assertThat(ri.primitiveMethod()).isEqualTo(0);
+        service.voidMethod("noResult", 100L);
 
         try {
-            ri.errorMethod();
-        } catch (IOException e) {
-            Assert.fail("fire-and-forget should not throw");
+            service.resultMethod(100L);
+            Assert.fail();
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
-            ri.errorMethodWithCause();
+            service.errorMethod();
+        } catch (IOException e) {
+            Assert.fail("noResult option should not throw server side exception");
+        }
+
+        try {
+            service.errorMethodWithCause();
         } catch (Exception e) {
-            Assert.fail("fire-and-forget should not throw");
+            Assert.fail("noResult option should not throw server side exception");
         }
 
         long time = System.currentTimeMillis();
-        ri.timeoutMethod();
+        service.timeoutMethod();
         time = System.currentTimeMillis() - time;
-        assertThat(time).describedAs("fire-and-forget should not wait for the server to return a response").isLessThan(2000);
+        assertThat(time).describedAs("noResult option should not wait for the server to return a response").isLessThan(2000);
 
-        r1.shutdown();
-        r2.shutdown();
+        try {
+            service.timeoutMethod();
+            Assert.fail("noResult option should still wait for the server to ack the request and throw if the ack timeout is exceeded");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RemoteServiceAckTimeoutException.class);
+        }
+
+        client.shutdown();
+        server.shutdown();
+    }
+
+    @Test
+    public void testNoAckWithoutResultInvocations() throws InterruptedException {
+        RedissonClient server = Redisson.create();
+        RedissonClient client = Redisson.create();
+
+        server.getRemoteSerivce().register(RemoteInterface.class, new RemoteImpl());
+
+        // no ack fire and forget
+        RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().noResult();
+        RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class, options);
+        RemoteInterface invalidService = client.getRemoteSerivce("Invalid").get(RemoteInterface.class, options);
+
+        service.voidMethod("noAck/noResult", 100L);
+
+        try {
+            service.resultMethod(100L);
+            Assert.fail();
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        try {
+            service.errorMethod();
+        } catch (IOException e) {
+            Assert.fail("noAck with noResult options should not throw server side exception");
+        }
+
+        try {
+            service.errorMethodWithCause();
+        } catch (Exception e) {
+            Assert.fail("noAck with noResult options should not throw server side exception");
+        }
+
+        long time = System.currentTimeMillis();
+        service.timeoutMethod();
+        time = System.currentTimeMillis() - time;
+        assertThat(time).describedAs("noAck with noResult options should not wait for the server to return a response").isLessThan(2000);
+
+        try {
+            invalidService.voidMethod("noAck/noResult", 21L);
+        } catch (Exception e) {
+            Assert.fail("noAck with noResult options should not throw any exception even while invoking a service in an unregistered services namespace");
+        }
+
+        client.shutdown();
+        server.shutdown();
     }
 }


### PR DESCRIPTION
This PR feels like a hack, because I made this just as a proof of concept.
I am very open to discuss this further.

Whit this PR, one can make unacknowledged and/or fire-and-forget calls (see #494).

In the `RRemoteService`'s `get(...)` methods that accepts `executionTimeout` and/or `ackTimeout`:
- pass a negative value into `executionTimeout` to make fire-and-forget calls
- pass a negative value into `ackTimeout` to make unacknowledged calls

There is many things not quite right with this implementation, here some that comes to mind:
- from a user perspective, it is not clear that a fire-and-forget call will returns the default value for the method return type (`0` for `int`, `null` for `Object`, etc...), so it is a bit misleading (the user explicitly want the call to return without result, so he expect none, but still...).
- again, from a user perspective, this hack enable client side typo (or other wrong calculation) into the `executionTimeout` to make a failing call (exception thrown server side) silent on the client side.
- it is not possible to disable the ack and still get this kind of request time-to-live in the queue (indeed, since the `ackTimeout` is negative, the server side must skip this TTL check and proceed with the call, otherwise the TTL check would always fail)