### PR TITLE
Tests for Redisson Remote Service with serialization based codec

### DIFF
--- a/src/main/java/org/redisson/remote/RRemoteServiceResponse.java
+++ b/src/main/java/org/redisson/remote/RRemoteServiceResponse.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.remote;
 
-public interface RRemoteServiceResponse {
+import java.io.Serializable;
+
+public interface RRemoteServiceResponse extends Serializable {
 
 }

--- a/src/main/java/org/redisson/remote/RemoteServiceAck.java
+++ b/src/main/java/org/redisson/remote/RemoteServiceAck.java
@@ -15,12 +15,14 @@
  */
 package org.redisson.remote;
 
+import java.io.Serializable;
+
 /**
  * Worker sends this message when it has received a {@link RemoteServiceRequest}. 
  * 
  * @author Nikita Koksharov
  *
  */
-public class RemoteServiceAck implements RRemoteServiceResponse {
+public class RemoteServiceAck implements RRemoteServiceResponse, Serializable {
 
 }

--- a/src/main/java/org/redisson/remote/RemoteServiceRequest.java
+++ b/src/main/java/org/redisson/remote/RemoteServiceRequest.java
@@ -15,9 +15,10 @@
  */
 package org.redisson.remote;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
-public class RemoteServiceRequest {
+public class RemoteServiceRequest implements Serializable {
 
     private String requestId;
     private String methodName;

--- a/src/main/java/org/redisson/remote/RemoteServiceResponse.java
+++ b/src/main/java/org/redisson/remote/RemoteServiceResponse.java
@@ -15,7 +15,9 @@
  */
 package org.redisson.remote;
 
-public class RemoteServiceResponse implements RRemoteServiceResponse {
+import java.io.Serializable;
+
+public class RemoteServiceResponse implements RRemoteServiceResponse, Serializable {
 
     private Object result;
     private Throwable error;


### PR DESCRIPTION
This contains two tests to show that Remote Service does not work with a serialization based codec.

I know this could be a design choice to not support serialization in Remote Service.

Indeed, it cause less upgrade problem if users use the default JSON based codec that is not subject to `InvalidClassException` caused by incompatible serialized form and wrong `serialVersionUID` and such.

Though, this one has an easy fix I can push to this PR if you feel this is a bug and not a design choice.