### PR TITLE
no remote call for toString, equals and hashCode on the client proxy

### DIFF
--- a/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/src/main/java/org/redisson/RedissonRemoteService.java
@@ -182,9 +182,18 @@ public class RedissonRemoteService implements RRemoteService {
     
     public <T> T get(final Class<T> remoteInterface, final long executionTimeout, final TimeUnit executionTimeUnit, 
                         final long ackTimeout, final TimeUnit ackTimeUnit) {
+        final String toString = getClass().getSimpleName() + "-" + remoteInterface.getSimpleName() + "-proxy-" + generateRequestId();
         InvocationHandler handler = new InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (method.getName().equals("toString")) {
+                    return toString;
+                } else if (method.getName().equals("equals")) {
+                    return proxy == args[0];
+                } else if (method.getName().equals("hashCode")) {
+                    return toString.hashCode();
+                }
+
                 String requestId = generateRequestId();
                 
                 String requestQueueName = name + ":{" + remoteInterface.getName() + "}";

--- a/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -205,4 +205,33 @@ public class RedissonRemoteServiceTest extends BaseTest {
         r1.shutdown();
         r2.shutdown();
     }
+
+    @Test
+    public void testProxyToStringEqualsAndHashCode() {
+        RedissonClient client = Redisson.create();
+        try {
+            RemoteInterface service = client.getRemoteSerivce().get(RemoteInterface.class);
+
+            try {
+                System.out.println(service.toString());
+            } catch (Exception e) {
+                Assert.fail("calling toString on the client service proxy should not make a remote call");
+            }
+
+            try {
+                assertThat(service.hashCode() == service.hashCode()).isTrue();
+            } catch (Exception e) {
+                Assert.fail("calling hashCode on the client service proxy should not make a remote call");
+            }
+
+            try {
+                assertThat(service.equals(service)).isTrue();
+            } catch (Exception e) {
+                Assert.fail("calling equals on the client service proxy should not make a remote call");
+            }
+
+        } finally {
+            client.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
We probably don't want to issue a remote call when calling `toString`, `equals` and `hashCode` on the `RedissonRemoteService` client proxy.

This one is debatable. Just discard the PR if you don't agree :)