### PR TITLE
Add support for getting a random set member

### DIFF
--- a/src/main/java/org/redisson/RedissonSet.java
+++ b/src/main/java/org/redisson/RedissonSet.java
@@ -145,6 +145,16 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V> {
     }
 
     @Override
+    public V random() {
+        return get(randomAsync());
+    }
+
+    @Override
+    public Future<V> randomAsync() {
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.SRANDMEMBER_SINGLE, getName());
+    }
+
+    @Override
     public Future<Boolean> removeAsync(Object o) {
         return commandExecutor.writeAsync(getName(o), codec, RedisCommands.SREM_SINGLE, getName(o), o);
     }

--- a/src/main/java/org/redisson/RedissonSetMultimapValues.java
+++ b/src/main/java/org/redisson/RedissonSetMultimapValues.java
@@ -195,6 +195,16 @@ public class RedissonSetMultimapValues<V> extends RedissonExpirable implements R
     }
 
     @Override
+    public V random() {
+        return get(randomAsync());
+    }
+
+    @Override
+    public Future<V> randomAsync() {
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.SRANDMEMBER_SINGLE, getName());
+    }
+
+    @Override
     public Future<Boolean> removeAsync(Object o) {
         return commandExecutor.evalWriteAsync(getName(), codec, EVAL_CONTAINS_VALUE,
                 "local expireDate = 92233720368547758; " +

--- a/src/main/java/org/redisson/api/RSetReactive.java
+++ b/src/main/java/org/redisson/api/RSetReactive.java
@@ -37,6 +37,14 @@ public interface RSetReactive<V> extends RCollectionReactive<V> {
     Publisher<V> removeRandom();
 
     /**
+     * Returns random element from set
+     * in async mode
+     *
+     * @return
+     */
+    Publisher<V> random();
+
+    /**
      * Move a member from this set to the given destination set in async mode.
      *
      * @param destination the destination set

--- a/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -130,6 +130,7 @@ public interface RedisCommands {
     RedisCommand<Boolean> SREM_SINGLE = new RedisCommand<Boolean>("SREM", new BooleanAmountReplayConvertor(), 2, ValueType.OBJECTS);
     RedisCommand<Boolean> SMOVE = new RedisCommand<Boolean>("SMOVE", new BooleanReplayConvertor(), 3);
     RedisCommand<Set<Object>> SMEMBERS = new RedisCommand<Set<Object>>("SMEMBERS", new ObjectSetReplayDecoder<Object>());
+    RedisCommand<Object> SRANDMEMBER_SINGLE = new RedisCommand<Object>("SRANDMEMBER");
     RedisCommand<ListScanResult<Object>> SSCAN = new RedisCommand<ListScanResult<Object>>("SSCAN", new NestedMultiDecoder(new ObjectListReplayDecoder<Object>(), new ListScanResultReplayDecoder()), ValueType.OBJECT);
     RedisCommand<ListScanResult<Object>> EVAL_SSCAN = new RedisCommand<ListScanResult<Object>>("EVAL", new NestedMultiDecoder(new ObjectListReplayDecoder<Object>(), new ListScanResultReplayDecoder()), ValueType.OBJECT);
     RedisCommand<ListScanResult<Object>> EVAL_ZSCAN = new RedisCommand<ListScanResult<Object>>("EVAL", new NestedMultiDecoder(new ObjectListReplayDecoder<Object>(), new ListScanResultReplayDecoder()), ValueType.OBJECT);

--- a/src/main/java/org/redisson/core/RSet.java
+++ b/src/main/java/org/redisson/core/RSet.java
@@ -34,6 +34,13 @@ public interface RSet<V> extends Set<V>, RExpirable, RSetAsync<V> {
     V removeRandom();
 
     /**
+     * Returns random element from set
+     *
+     * @return
+     */
+    V random();
+
+    /**
      * Move a member from this set to the given destination set in.
      *
      * @param destination the destination set

--- a/src/main/java/org/redisson/core/RSetAsync.java
+++ b/src/main/java/org/redisson/core/RSetAsync.java
@@ -37,6 +37,14 @@ public interface RSetAsync<V> extends RCollectionAsync<V> {
     Future<V> removeRandomAsync();
 
     /**
+     * Returns random element from set
+     * in async mode
+     *
+     * @return
+     */
+    Future<V> randomAsync();
+
+    /**
      * Move a member from this set to the given destination set in async mode.
      *
      * @param destination the destination set

--- a/src/main/java/org/redisson/reactive/RedissonSetReactive.java
+++ b/src/main/java/org/redisson/reactive/RedissonSetReactive.java
@@ -81,6 +81,11 @@ public class RedissonSetReactive<V> extends RedissonExpirableReactive implements
     }
 
     @Override
+    public Publisher<V> random() {
+        return reactive(instance.randomAsync());
+    }
+
+    @Override
     public Publisher<Boolean> remove(Object o) {
         return reactive(instance.removeAsync(o));
     }

--- a/src/test/java/org/redisson/RedissonSetReactiveTest.java
+++ b/src/test/java/org/redisson/RedissonSetReactiveTest.java
@@ -64,9 +64,9 @@ public class RedissonSetReactiveTest extends BaseReactiveTest {
         sync(set.add(2));
         sync(set.add(3));
 
-        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
-        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
-        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
+        MatcherAssert.assertThat(sync(set.random()), Matchers.isOneOf(1, 2, 3));
+        MatcherAssert.assertThat(sync(set.random()), Matchers.isOneOf(1, 2, 3));
+        MatcherAssert.assertThat(sync(set.random()), Matchers.isOneOf(1, 2, 3));
         Assert.assertThat(sync(set), Matchers.containsInAnyOrder(1, 2, 3));
     }
 

--- a/src/test/java/org/redisson/RedissonSetReactiveTest.java
+++ b/src/test/java/org/redisson/RedissonSetReactiveTest.java
@@ -58,6 +58,19 @@ public class RedissonSetReactiveTest extends BaseReactiveTest {
     }
 
     @Test
+    public void testRandom() {
+        RSetReactive<Integer> set = redisson.getSet("simple");
+        sync(set.add(1));
+        sync(set.add(2));
+        sync(set.add(3));
+
+        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
+        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
+        MatcherAssert.assertThat(sync(set.removeRandom()), Matchers.isOneOf(1, 2, 3));
+        Assert.assertThat(sync(set), Matchers.containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
     public void testAddBean() throws InterruptedException, ExecutionException {
         SimpleBean sb = new SimpleBean();
         sb.setLng(1L);

--- a/src/test/java/org/redisson/RedissonSetTest.java
+++ b/src/test/java/org/redisson/RedissonSetTest.java
@@ -53,9 +53,9 @@ public class RedissonSetTest extends BaseTest {
         set.add(2);
         set.add(3);
 
-        assertThat(set.removeRandom()).isIn(1, 2, 3);
-        assertThat(set.removeRandom()).isIn(1, 2, 3);
-        assertThat(set.removeRandom()).isIn(1, 2, 3);
+        assertThat(set.random()).isIn(1, 2, 3);
+        assertThat(set.random()).isIn(1, 2, 3);
+        assertThat(set.random()).isIn(1, 2, 3);
         assertThat(set).containsOnly(1, 2, 3);
     }
 

--- a/src/test/java/org/redisson/RedissonSetTest.java
+++ b/src/test/java/org/redisson/RedissonSetTest.java
@@ -47,6 +47,19 @@ public class RedissonSetTest extends BaseTest {
     }
 
     @Test
+    public void testRandom() {
+        RSet<Integer> set = redisson.getSet("simple");
+        set.add(1);
+        set.add(2);
+        set.add(3);
+
+        assertThat(set.removeRandom()).isIn(1, 2, 3);
+        assertThat(set.removeRandom()).isIn(1, 2, 3);
+        assertThat(set.removeRandom()).isIn(1, 2, 3);
+        assertThat(set).containsOnly(1, 2, 3);
+    }
+
+    @Test
     public void testAddBean() throws InterruptedException, ExecutionException {
         SimpleBean sb = new SimpleBean();
         sb.setLng(1L);


### PR DESCRIPTION
This adds `RSet.random()` and `RSetAsync.randomAsync()` support via the `SRANDMEMBER` command.  Getting a random member without removing it from the set.